### PR TITLE
Enhancement #118: Adding riverside location and achievement

### DIFF
--- a/src/main/java/org/mafagafogigante/dungeon/game/LocationPreset.java
+++ b/src/main/java/org/mafagafogigante/dungeon/game/LocationPreset.java
@@ -117,6 +117,6 @@ public final class LocationPreset {
     this.blobSize = blobSize;
   }
 
-  public enum Type {RIVER, BRIDGE, DUNGEON_ENTRANCE, DUNGEON_STAIRWAY, DUNGEON_ROOM, DUNGEON_CORRIDOR, LAND}
+  public enum Type {RIVER, BRIDGE, DUNGEON_ENTRANCE, DUNGEON_STAIRWAY, DUNGEON_ROOM, DUNGEON_CORRIDOR, LAND, RIVERSIDE}
 
 }

--- a/src/main/java/org/mafagafogigante/dungeon/game/RiverGenerator.java
+++ b/src/main/java/org/mafagafogigante/dungeon/game/RiverGenerator.java
@@ -58,4 +58,13 @@ final class RiverGenerator implements Serializable {
     return river != null && river.isBridge(point.getY());
   }
 
+  /**
+   * Returns if in this point there should be a riverside.
+   */
+  boolean isRiverside(Point point) {
+    River leftOfRiver = rivers.get(point.getX() - 1);
+    River rightOfRiver = rivers.get(point.getX() + 1);
+    return leftOfRiver != null || rightOfRiver != null;
+  }
+
 }

--- a/src/main/java/org/mafagafogigante/dungeon/game/WorldGenerator.java
+++ b/src/main/java/org/mafagafogigante/dungeon/game/WorldGenerator.java
@@ -47,6 +47,11 @@ class WorldGenerator implements Serializable {
     return new Location(Random.select(locationPresetStore.getLocationPresetsByType(Type.BRIDGE)), world, point);
   }
 
+  private Location createRiversideLocation(@NotNull final Point point) {
+    LocationPresetStore locationPresetStore = LocationPresetStore.getDefaultLocationPresetStore();
+    return new Location(Random.select(locationPresetStore.getLocationPresetsByType(Type.RIVERSIDE)), world, point);
+  }
+
   public void expand(Point point) {
     riverGenerator.expand(point, chunkSide);
     Point currentPoint;
@@ -66,6 +71,8 @@ class WorldGenerator implements Serializable {
             world.addLocation(createRandomRiverLocation(currentPoint), currentPoint);
           } else if (riverGenerator.isBridge(currentPoint)) {
             world.addLocation(createRandomBridgeLocation(currentPoint), currentPoint);
+          } else if (riverGenerator.isRiverside(currentPoint)) {
+            world.addLocation(createRiversideLocation(currentPoint), currentPoint);
           } else if (dungeonDistributor.rollForDungeon(currentPoint)) {
             dungeonCreator.createDungeon(world, currentPoint);
           } else {

--- a/src/main/resources/achievements.json
+++ b/src/main/resources/achievements.json
@@ -646,6 +646,17 @@
       }
     },
     {
+      "id": "DOWN_BY_THE_RIVERSIDE",
+      "name": "Down By the Riverside",
+      "info": "Visit 10 different riversides.",
+      "text": "visited ten different riversides",
+      "explorationRequirements": {
+        "visitedLocations": {
+          "RIVERSIDE": 10
+        }
+      }
+    },
+    {
       "id": "REAPER",
       "name": "Reaper",
       "info": "Visit 10 distinct graveyards.",

--- a/src/main/resources/locations.json
+++ b/src/main/resources/locations.json
@@ -1157,6 +1157,69 @@
           "probability": 0.05
         }
       ]
+    },
+    {
+      "id": "RIVERSIDE",
+      "type": "RIVERSIDE",
+      "name": {
+        "singular": "Riverside"
+      },
+      "color": [
+        100,
+        250,
+        200
+      ],
+      "symbol": "R",
+      "info": "The is an area with a flowing river. The river seems to be brimming with fish.",
+      "blobSize": 0,
+      "lightPermittivity": 1,
+      "blockedEntrances": [
+        "U",
+        "D"
+      ],
+      "spawners": [
+        {
+          "id": "FROG",
+          "population": {
+            "minimum": 1,
+            "maximum": 3
+          },
+          "delay": 2
+        },
+        {
+          "id": "GREEN_IGUANA",
+          "population": {
+            "minimum": 2,
+            "maximum": 2
+          },
+          "delay": 32
+        },
+        {
+          "id": "TRAVELER",
+          "population": {
+            "minimum": 1,
+            "maximum": 2
+          },
+          "delay": 36
+        }
+      ],
+      "tags": [
+        "FISHABLE"
+      ],
+      "items": [
+        {
+          "id": "STONE",
+          "probability": 0.3
+        },
+        {
+          "id": "SPEAR",
+          "probability": 0.1
+        },
+        {
+          "id": "STICK",
+          "probability": 0.3
+        }
+      ]
     }
   ]
 }

--- a/src/test/java/org/mafagafogigante/dungeon/io/AchievementsJsonFileTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/io/AchievementsJsonFileTest.java
@@ -20,6 +20,7 @@ public class AchievementsJsonFileTest extends ResourcesTypeTest {
   private static final String QUERY_FIELD = "query";
   private static final String FOREST_FIELD = "FOREST";
   private static final String DESERT_FIELD = "DESERT";
+  private static final String RIVERSIDE_FIELD = "RIVERSIDE";
   private static final String GRAVEYARD_FIELD = "GRAVEYARD";
   private static final String PART_OF_DAY_FIELD = "partOfDay";
   private static final String ACHIEVEMENTS_FIELD = "achievements";
@@ -121,6 +122,7 @@ public class AchievementsJsonFileTest extends ResourcesTypeTest {
     Map<String, JsonRule> visitedLocationsRules = new HashMap<>();
     JsonRule optionalIntegerRule = JsonRuleFactory.makeOptionalRule(JsonRuleFactory.makeIntegerRule());
     visitedLocationsRules.put(DESERT_FIELD, optionalIntegerRule);
+    visitedLocationsRules.put(RIVERSIDE_FIELD, optionalIntegerRule);
     visitedLocationsRules.put(GRAVEYARD_FIELD, optionalIntegerRule);
     return JsonRuleFactory.makeObjectRule(visitedLocationsRules);
   }


### PR DESCRIPTION
After manual testing and running `mvn test`, changes seems to work successfully.

- Added location riverside
- Added functions for riverside location to only appear left and right of river/bridge location
- Added achievement for visiting 10 different riverside (Not sure how rewarding this achievement is, since riversides spawn along the river)
- Edited `AchievementsJsonFileTest.java` to include rule for new riverside achievement. (Unsure what the rule functionality does, even after looking through it)