### PR TITLE
Issue #281: fungi

### DIFF
--- a/src/main/resources/items.json
+++ b/src/main/resources/items.json
@@ -261,34 +261,6 @@
       "integrityDecrementOnEat": 5
     },
     {
-      "id": "GLOWING_MOSS",
-      "type": "Food",
-      "name": {
-        "singular": "Glowing Moss",
-        "plural": "Glowing Mosses"
-      },
-      "rarity": "COMMON",
-      "tags": [
-        "WEAPON",
-        "FOOD",
-        "DECOMPOSES",
-        "WEIGHT_PROPORTIONAL_TO_INTEGRITY"
-      ],
-      "integrity": {
-        "current": 5,
-        "maximum": 5
-      },
-      "weight": 0.01,
-      "visibility": "50.00%",
-      "decompositionPeriod": "1 month",
-      "damage": 1,
-      "hitRate": "35.00%",
-      "integrityDecrementOnHit": 2,
-      "nutrition": 3,
-      "integrityDecrementOnEat": 5,
-      "luminosity": "30.00%"
-    },
-    {
       "id": "HEALING_POTION",
       "type": "Potion",
       "name": {

--- a/src/main/resources/items.json
+++ b/src/main/resources/items.json
@@ -261,6 +261,34 @@
       "integrityDecrementOnEat": 5
     },
     {
+      "id": "GLOWING_MOSS",
+      "type": "Food",
+      "name": {
+        "singular": "Glowing Moss",
+        "plural": "Glowing Mosses"
+      },
+      "rarity": "COMMON",
+      "tags": [
+        "WEAPON",
+        "FOOD",
+        "DECOMPOSES",
+        "WEIGHT_PROPORTIONAL_TO_INTEGRITY"
+      ],
+      "integrity": {
+        "current": 5,
+        "maximum": 5
+      },
+      "weight": 0.01,
+      "visibility": "50.00%",
+      "decompositionPeriod": "1 month",
+      "damage": 1,
+      "hitRate": "35.00%",
+      "integrityDecrementOnHit": 2,
+      "nutrition": 3,
+      "integrityDecrementOnEat": 5,
+      "luminosity": "30.00%"
+    },
+    {
       "id": "HEALING_POTION",
       "type": "Potion",
       "name": {

--- a/src/main/resources/items.json
+++ b/src/main/resources/items.json
@@ -207,6 +207,33 @@
       "integrityDecrementOnEat": 10
     },
     {
+      "id": "CYAN_FUNGUS",
+      "type": "Food",
+      "name": {
+        "singular": "Cyan fungus",
+        "plural": "Cyan fungi"
+      },
+      "rarity": "COMMON",
+      "tags": [
+        "WEAPON",
+        "FOOD",
+        "DECOMPOSES",
+        "WEIGHT_PROPORTIONAL_TO_INTEGRITY"
+      ],
+      "integrity": {
+        "current": 5,
+        "maximum": 5
+      },
+      "weight": 0.05,
+      "visibility": "60.00%",
+      "decompositionPeriod": "7 days",
+      "damage": 3,
+      "hitRate": "60.00%",
+      "integrityDecrementOnHit": 5,
+      "nutrition": 5,
+      "integrityDecrementOnEat": 5
+    },
+    {
       "id": "HEALING_POTION",
       "type": "Potion",
       "name": {

--- a/src/main/resources/items.json
+++ b/src/main/resources/items.json
@@ -234,11 +234,11 @@
       "integrityDecrementOnEat": 5
     },
     {
-      "id": "CYAN_FUNGUS2",
+      "id": "AMBER_FUNGUS2",
       "type": "Food",
       "name": {
-        "singular": "Cyan fungus",
-        "plural": "Cyan fungi"
+        "singular": "Amber Fungus",
+        "plural": "Amber Fungi"
       },
       "rarity": "COMMON",
       "tags": [

--- a/src/main/resources/items.json
+++ b/src/main/resources/items.json
@@ -210,8 +210,8 @@
       "id": "CYAN_FUNGUS",
       "type": "Food",
       "name": {
-        "singular": "Cyan fungus",
-        "plural": "Cyan fungi"
+        "singular": "Cyan Fungus",
+        "plural": "Cyan Fungi"
       },
       "rarity": "COMMON",
       "tags": [

--- a/src/main/resources/items.json
+++ b/src/main/resources/items.json
@@ -234,6 +234,33 @@
       "integrityDecrementOnEat": 5
     },
     {
+      "id": "AMBER_FUNGUS",
+      "type": "Food",
+      "name": {
+        "singular": "Amber Fungus",
+        "plural": "Amber Fungi"
+      },
+      "rarity": "COMMON",
+      "tags": [
+        "WEAPON",
+        "FOOD",
+        "DECOMPOSES",
+        "WEIGHT_PROPORTIONAL_TO_INTEGRITY"
+      ],
+      "integrity": {
+        "current": 5,
+        "maximum": 5
+      },
+      "weight": 0.05,
+      "visibility": "60.00%",
+      "decompositionPeriod": "7 days",
+      "damage": 3,
+      "hitRate": "60.00%",
+      "integrityDecrementOnHit": 5,
+      "nutrition": 8,
+      "integrityDecrementOnEat": 5
+    },
+    {
       "id": "AMBER_FUNGUS2",
       "type": "Food",
       "name": {

--- a/src/main/resources/items.json
+++ b/src/main/resources/items.json
@@ -234,6 +234,33 @@
       "integrityDecrementOnEat": 5
     },
     {
+      "id": "CYAN_FUNGUS2",
+      "type": "Food",
+      "name": {
+        "singular": "Cyan fungus",
+        "plural": "Cyan fungi"
+      },
+      "rarity": "COMMON",
+      "tags": [
+        "WEAPON",
+        "FOOD",
+        "DECOMPOSES",
+        "WEIGHT_PROPORTIONAL_TO_INTEGRITY"
+      ],
+      "integrity": {
+        "current": 5,
+        "maximum": 5
+      },
+      "weight": 0.05,
+      "visibility": "60.00%",
+      "decompositionPeriod": "7 days",
+      "damage": 3,
+      "hitRate": "60.00%",
+      "integrityDecrementOnHit": 5,
+      "nutrition": -3,
+      "integrityDecrementOnEat": 5
+    },
+    {
       "id": "HEALING_POTION",
       "type": "Potion",
       "name": {

--- a/src/main/resources/items.json
+++ b/src/main/resources/items.json
@@ -261,7 +261,7 @@
       "integrityDecrementOnEat": 5
     },
     {
-      "id": "AMBER_FUNGUS2",
+      "id": "TOXIC_AMBER_FUNGUS",
       "type": "Food",
       "name": {
         "singular": "Amber Fungus",

--- a/src/main/resources/locations.json
+++ b/src/main/resources/locations.json
@@ -191,6 +191,10 @@
           "probability": 0.3
         },
         {
+          "id": "AMBER_FUNGUS",
+          "probability": 0.3
+        },
+        {
           "id": "AMBER_FUNGUS2",
           "probability": 0.3
         }
@@ -279,6 +283,10 @@
           "probability": 0.3
         },
         {
+          "id": "AMBER_FUNGUS",
+          "probability": 0.3
+        },
+        {
           "id": "AMBER_FUNGUS2",
           "probability": 0.3
         }
@@ -341,6 +349,10 @@
           "probability": 0.3
         },
         {
+          "id": "AMBER_FUNGUS",
+          "probability": 0.3
+        },
+        {
           "id": "AMBER_FUNGUS2",
           "probability": 0.3
         }
@@ -392,6 +404,10 @@
         },
         {
           "id": "CYAN_FUNGUS",
+          "probability": 0.3
+        },
+        {
+          "id": "AMBER_FUNGUS",
           "probability": 0.3
         },
         {
@@ -464,6 +480,10 @@
         },
         {
           "id": "CYAN_FUNGUS",
+          "probability": 0.3
+        },
+        {
+          "id": "AMBER_FUNGUS",
           "probability": 0.3
         },
         {
@@ -1126,6 +1146,10 @@
         },
         {
           "id": "CYAN_FUNGUS",
+          "probability": 0.5
+        },
+        {
+          "id": "AMBER_FUNGUS",
           "probability": 0.5
         },
         {

--- a/src/main/resources/locations.json
+++ b/src/main/resources/locations.json
@@ -185,6 +185,14 @@
         {
           "id": "HISTORY_OF_THE_THIRD_ERA",
           "probability": 0.05
+        },
+        {
+          "id": "CYAN_FUNGUS",
+          "probability": 0.3
+        },
+        {
+          "id": "CYAN_FUNGUS2",
+          "probability": 0.3
         }
       ]
     },
@@ -265,6 +273,14 @@
         {
           "id": "TOME_OF_DISPLACE",
           "probability": 0.05
+        },
+        {
+          "id": "CYAN_FUNGUS",
+          "probability": 0.3
+        },
+        {
+          "id": "CYAN_FUNGUS2",
+          "probability": 0.3
         }
       ]
     },
@@ -319,6 +335,14 @@
         {
           "id": "TOME_OF_FINGER_OF_DEATH",
           "probability": 0.05
+        },
+        {
+          "id": "CYAN_FUNGUS",
+          "probability": 0.3
+        },
+        {
+          "id": "CYAN_FUNGUS2",
+          "probability": 0.3
         }
       ]
     },
@@ -365,6 +389,14 @@
         {
           "id": "TOME_OF_PERCEIVE",
           "probability": 0.05
+        },
+        {
+          "id": "CYAN_FUNGUS",
+          "probability": 0.3
+        },
+        {
+          "id": "CYAN_FUNGUS2",
+          "probability": 0.5
         }
       ]
     },
@@ -429,6 +461,14 @@
         {
           "id": "TOME_OF_PERCEIVE",
           "probability": 0.05
+        },
+        {
+          "id": "CYAN_FUNGUS",
+          "probability": 0.3
+        },
+        {
+          "id": "CYAN_FUNGUS2",
+          "probability": 0.5
         }
       ]
     },

--- a/src/main/resources/locations.json
+++ b/src/main/resources/locations.json
@@ -195,7 +195,7 @@
           "probability": 0.3
         },
         {
-          "id": "AMBER_FUNGUS2",
+          "id": "TOXIC_AMBER_FUNGUS",
           "probability": 0.3
         }
       ]
@@ -287,7 +287,7 @@
           "probability": 0.3
         },
         {
-          "id": "AMBER_FUNGUS2",
+          "id": "TOXIC_AMBER_FUNGUS",
           "probability": 0.3
         }
       ]
@@ -353,7 +353,7 @@
           "probability": 0.3
         },
         {
-          "id": "AMBER_FUNGUS2",
+          "id": "TOXIC_AMBER_FUNGUS",
           "probability": 0.3
         }
       ]
@@ -411,7 +411,7 @@
           "probability": 0.3
         },
         {
-          "id": "AMBER_FUNGUS2",
+          "id": "TOXIC_AMBER_FUNGUS",
           "probability": 0.5
         }
       ]
@@ -487,7 +487,7 @@
           "probability": 0.3
         },
         {
-          "id": "AMBER_FUNGUS2",
+          "id": "TOXIC_AMBER_FUNGUS",
           "probability": 0.5
         }
       ]
@@ -1153,7 +1153,7 @@
           "probability": 0.5
         },
         {
-          "id": "AMBER_FUNGUS2",
+          "id": "TOXIC_AMBER_FUNGUS",
           "probability": 0.5
         }
       ]

--- a/src/main/resources/locations.json
+++ b/src/main/resources/locations.json
@@ -1083,6 +1083,14 @@
         {
           "id": "CLUB",
           "probability": 0.4
+        },
+        {
+          "id": "CYAN_FUNGUS",
+          "probability": 0.5
+        },
+        {
+          "id": "CYAN_FUNGUS2",
+          "probability": 0.5
         }
       ]
     },

--- a/src/main/resources/locations.json
+++ b/src/main/resources/locations.json
@@ -191,7 +191,7 @@
           "probability": 0.3
         },
         {
-          "id": "CYAN_FUNGUS2",
+          "id": "AMBER_FUNGUS2",
           "probability": 0.3
         }
       ]
@@ -279,7 +279,7 @@
           "probability": 0.3
         },
         {
-          "id": "CYAN_FUNGUS2",
+          "id": "AMBER_FUNGUS2",
           "probability": 0.3
         }
       ]
@@ -341,7 +341,7 @@
           "probability": 0.3
         },
         {
-          "id": "CYAN_FUNGUS2",
+          "id": "AMBER_FUNGUS2",
           "probability": 0.3
         }
       ]
@@ -395,7 +395,7 @@
           "probability": 0.3
         },
         {
-          "id": "CYAN_FUNGUS2",
+          "id": "AMBER_FUNGUS2",
           "probability": 0.5
         }
       ]
@@ -467,7 +467,7 @@
           "probability": 0.3
         },
         {
-          "id": "CYAN_FUNGUS2",
+          "id": "AMBER_FUNGUS2",
           "probability": 0.5
         }
       ]
@@ -1129,7 +1129,7 @@
           "probability": 0.5
         },
         {
-          "id": "CYAN_FUNGUS2",
+          "id": "AMBER_FUNGUS2",
           "probability": 0.5
         }
       ]


### PR DESCRIPTION
Current PR:
Adds CYAN_FUNGUS, AMBER_FUNGUS, and AMBER_FUNGUS2 (which appears the same in name as AMBER_FUNGUS but damages the Hero) to the items.json file and to the swamp and dungeon rooms in the locations.json file.

Future Issue:
This brings up the issue that there should be a message that appears if a food item damages the Hero, as it could easily escape notice that some of the Amber Fungi do damage. This could be added by displaying a message after each eat command with either "The <food-item> has healed you for # points" or "You feel <better | much better | sick> after eating <food-item>" depending on how much information you want to give the player and how much assigning a solid number to a healing value breaks world immersion. In the long term, Hero statistics like intelligence or awareness could potentially be attached to the amount of information displayed and/or the accuracy of that information, but in the short term some message should be provided if we're introducing poisonous food.