### PR TITLE
Closes #112: Add map legend

### DIFF
--- a/src/main/java/org/mafagafogigante/dungeon/map/WorldMapWriter.java
+++ b/src/main/java/org/mafagafogigante/dungeon/map/WorldMapWriter.java
@@ -1,10 +1,17 @@
 package org.mafagafogigante.dungeon.map;
 
+import org.mafagafogigante.dungeon.game.Direction;
 import org.mafagafogigante.dungeon.game.DungeonString;
+import org.mafagafogigante.dungeon.game.Game;
+import org.mafagafogigante.dungeon.game.Location;
+import org.mafagafogigante.dungeon.game.Point;
 import org.mafagafogigante.dungeon.gui.GameWindow;
 import org.mafagafogigante.dungeon.io.Writer;
 
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public final class WorldMapWriter {
 
@@ -36,13 +43,29 @@ public final class WorldMapWriter {
   private static void renderMap(@NotNull WorldMap map) {
     DungeonString string = new DungeonString();
     WorldMapSymbol[][] worldMapSymbolMatrix = map.getSymbolMatrix();
-    for (int i = 0; i < worldMapSymbolMatrix.length; i++) {
+    for (int i = 0; i < worldMapSymbolMatrix.length - 2; i++) {
       for (WorldMapSymbol symbol : worldMapSymbolMatrix[i]) {
         // OK as setColor verifies if the color change is necessary (does not replace a color by itself).
         string.setColor(symbol.getColor());
         string.append(symbol.getCharacterAsString());
       }
       if (i < worldMapSymbolMatrix.length - 1) {
+        string.append("\n");
+      }
+    }
+
+    //Rendering the map legend
+    ArrayList<Direction> directions = new ArrayList<>(Arrays.asList(Direction.values()));
+    directions.remove(Direction.UP);
+    directions.remove(Direction.DOWN);
+    for (int i = 0; i < directions.size(); i++) {
+      Point adjacentPoint = new Point(Game.getGameState().getHero().getLocation().getPoint(), directions.get(i));
+      if (Game.getGameState().getWorld().hasLocationAt(adjacentPoint)) {
+        Location adjacentLocation = Game.getGameState().getWorld().getLocation(adjacentPoint);
+        string.append("\t\t" + adjacentLocation.getName().getSingular().substring(0, 1) + " - " +
+                adjacentLocation.getName().getSingular());
+      }
+      if (i == 1) {
         string.append("\n");
       }
     }


### PR DESCRIPTION
**Creating pull request for feedback.** I'm not happy with how I developed the map legend but unsure where to move forward with this.
- - -
Currently the map legend is retrieving adjacent locations relative to the player. So only 4 locations, north, east, south, and west of the player.
- - -
**Known problems**:
**Formatting of map legend text is sometimes off** (I'm open to any solution, otherwise Ill keep looking for a solution) 
(**Update**: One solution I found is to use `String.format("%-32s", text);` to format the string correctly):
![image](https://user-images.githubusercontent.com/30512065/68959382-e9ad5e80-079b-11ea-8f23-ef91017129e4.png)
- - -
**Duplicate locations/Map legend shows unexplored locations even though player can't see**:
![image](https://user-images.githubusercontent.com/30512065/68956266-b7006780-0795-11ea-9667-3bb41549e2d3.png)

I was thinking maybe I could use a `Set` collocation instead of taking adjacent locations. `Set` are unordered and do not have duplicates (Map legend will show randomly explored locations, I could also probably show 6 locations instead of just four). The problem is I will be checking every symbol on the map to see if it was explored which should make the `map` command slower.

I was wondering if there is a function that gives me a list of explored areas?

I will keep working on this issue, but if you have any feedback or suggestion I am all ears.