### PR TITLE
Closes #112: Add WorldMapLegend class

### DIFF
--- a/src/main/java/org/mafagafogigante/dungeon/map/WorldMapLegend.java
+++ b/src/main/java/org/mafagafogigante/dungeon/map/WorldMapLegend.java
@@ -1,0 +1,51 @@
+package org.mafagafogigante.dungeon.map;
+
+import org.mafagafogigante.dungeon.game.DungeonString;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+
+public final class WorldMapLegend {
+  /**
+   * Setting the amount of locations to display. MAX_LEGEND_LOCATIONS needs to be an even number for proper formatting.
+   */
+  private static final int MAX_LEGEND_LOCATIONS = 6;
+  private static final int INITIAL_SPACE_VALUE = MAX_LEGEND_LOCATIONS / 2;
+  private static final int NEW_LINE_VALUE = INITIAL_SPACE_VALUE - 1;
+
+  private WorldMapLegend() {
+    throw new AssertionError();
+  }
+
+  static void renderLegend(@NotNull WorldMapSymbol[][] worldMapSymbolMatrix, @NotNull DungeonString string) {
+    Set<WorldMapSymbol> symbols = new HashSet<>();
+    int centerI = (worldMapSymbolMatrix.length - 2) / 2 + 1;
+    int centerJ = worldMapSymbolMatrix[centerI].length / 2 - 1;
+    symbols.add(worldMapSymbolMatrix[centerI - 1][centerJ]);
+    symbols.add(worldMapSymbolMatrix[centerI - 1][centerJ - 1]);
+    symbols.add(worldMapSymbolMatrix[centerI][centerJ - 1]);
+    symbols.add(worldMapSymbolMatrix[centerI - 1][centerJ + 1]);
+    symbols.add(worldMapSymbolMatrix[centerI][centerJ + 1]);
+    symbols.add(worldMapSymbolMatrix[centerI + 1][centerJ - 1]);
+    symbols.add(worldMapSymbolMatrix[centerI + 1][centerJ]);
+    symbols.add(worldMapSymbolMatrix[centerI + 1][centerJ + 1]);
+
+    Iterator<WorldMapSymbol> it = symbols.iterator();
+    for (int i = 0; i < MAX_LEGEND_LOCATIONS && it.hasNext(); i++) {
+      WorldMapSymbol symbol = it.next();
+      if (i % INITIAL_SPACE_VALUE == 0) {
+        string.append(String.format("%-2s", ""));
+      }
+      string.setColor(symbol.getColor());
+      string.append(String.format("%-32s", (symbol.getCharacterAsString() + " - " + symbol.getName())));
+      string.resetColor();
+      if (i == NEW_LINE_VALUE) {
+        string.append("\n");
+      }
+    }
+  }
+}

--- a/src/main/java/org/mafagafogigante/dungeon/map/WorldMapSymbol.java
+++ b/src/main/java/org/mafagafogigante/dungeon/map/WorldMapSymbol.java
@@ -54,6 +54,24 @@ class WorldMapSymbol {
   }
 
   @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+
+    WorldMapSymbol that = (WorldMapSymbol) object;
+    return name.equals(that.name) && character.equals(that.character) && color.equals(that.color);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * name.hashCode() + character.hashCode() + color.hashCode();
+  }
+
+  @Override
   public String toString() {
     return "WorldMapSymbol{" +
             "name='" + name + '\'' +

--- a/src/main/java/org/mafagafogigante/dungeon/map/WorldMapWriter.java
+++ b/src/main/java/org/mafagafogigante/dungeon/map/WorldMapWriter.java
@@ -6,9 +6,6 @@ import org.mafagafogigante.dungeon.io.Writer;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public final class WorldMapWriter {
 
   private WorldMapWriter() {
@@ -31,29 +28,6 @@ public final class WorldMapWriter {
     return GameWindow.getColumns();
   }
 
-  private static void renderLegend(@NotNull WorldMapSymbol[][] worldMapSymbolMatrix, @NotNull DungeonString string) {
-    List<WorldMapSymbol> symbols = new ArrayList<>();
-    int centerI = (worldMapSymbolMatrix.length - 2) / 2 + 1;
-    int centerJ = worldMapSymbolMatrix[centerI].length / 2 - 1;
-    symbols.add(worldMapSymbolMatrix[centerI - 1][centerJ]);
-    symbols.add(worldMapSymbolMatrix[centerI][centerJ - 1]);
-    symbols.add(worldMapSymbolMatrix[centerI][centerJ + 1]);
-    symbols.add(worldMapSymbolMatrix[centerI + 1][centerJ]);
-    for (int i = 0; i < symbols.size(); i++) {
-      if (i % 2 == 0) {
-        string.append(String.format("%-16s", ""));
-      }
-      WorldMapSymbol symbol = symbols.get(i);
-      string.setColor(symbol.getColor());
-      string.append(symbol.getCharacterAsString());
-      string.resetColor();
-      string.append(String.format(" - %-32s", symbol.getName()));
-      if (i % 2 != 0) {
-        string.append("\n");
-      }
-    }
-  }
-
   /**
    * Writes a WorldMap to the screen. This erases all the content currently on the screen.
    *
@@ -72,7 +46,7 @@ public final class WorldMapWriter {
         string.append("\n");
       }
     }
-    renderLegend(worldMapSymbolMatrix, string);
+    WorldMapLegend.renderLegend(worldMapSymbolMatrix, string);
     Writer.write(string);
   }
 


### PR DESCRIPTION
Added `WorldMapLegend` class for future map legend development (Currently `WorldMapLegend` class can control the amount of locations to appear in the map legend, but that's about it. Hopefully in future builds `WorldMapLegend` will have more use). 

- Moving the `renderLegend` function into the `WorldMapLegend` class I changed the function to also take NW,NE,SE,SW making it 8 locations near the player. `renderLegend` now displays 6 locations.

- `renderLegend` now uses a `Set` instead of an `ArrayList`, to get non-duplicate locations.

- Since I am using a `Set`, I added the `hashCode` and `equals` function to `WorldMapSymbol` class. I never implemented a `hashCode` function before so I copied the one in `creatures\ColoredString` and tailored it to `WorldMapSymbol`. Hopefully it's correct.


- - -
As of the current build, the map legend adds a newline after the last two location letting you scroll on the map command (It's hard to see but you can scroll up and down, which I assume is not wanted):
![image](https://user-images.githubusercontent.com/30512065/69013824-73069180-0952-11ea-9ac8-7fa1f9197207.png)

I use `==` here instead of modules to fix this: `if (i == NEW_LINE_VALUE)` (Since module adds another new line).

- - -
I changed the locations text on the map legend to also be colored. This made the formatting easier for the 6 locations. If you don't like it I can try to change it back 👍 . 
 
Using the longest location name "Ancient Dungeon Room" I was able to check if there was any problems with the formatting:
![image](https://user-images.githubusercontent.com/30512065/69013751-a8f74600-0951-11ea-97ec-df7d61aca142.png)
Seems good! May be a problem in the future if there are longer location names, but you can change the amount of locations displayed on the map legend using `MAX_LEGEND_LOCATIONS`.
- - -
Couldn't use `forEach` for set because there's a small chance you can get more then 6 locations (I use a `for` loop and a `Iterator`):
![image](https://user-images.githubusercontent.com/30512065/69013712-3d14dd80-0951-11ea-8c9d-5b6cd651da4f.png)
- - -
Referencing https://github.com/bernardosulzbach/dungeon/pull/423:
> Some outstanding issues after what I did: the WorldMap is larger than it needs to be (we ignore the first and last line), the calculation for the player position is a bit... arbitrary. Should probably be done by WorldMap (which really knows where the player is in the matrix). Lastly, the redundancy generated by only using adjacent locations is an issue (see image below). You can move on with any of these improvements and I will be glad to review your work on them.

This PR fixes the redundancy but there may be a different way, using the classes `WorldMapLegend` and `WorldMap` together to produce a map legend.