### PR TITLE
Fixes #419: Allow spaces in project directory

### DIFF
--- a/src/test/java/org/mafagafogigante/dungeon/io/ResourcesFolderTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/io/ResourcesFolderTest.java
@@ -26,12 +26,12 @@ public class ResourcesFolderTest {
    * Try to initialize the resources directory.
    */
   @Before
-  public void initialize() {
+  public void initialize() throws Exception {
     URL resourcesUrl = this.getClass().getClassLoader().getResource(RESOURCES_TARGET_PATH);
     if (resourcesUrl != null) {
-      resourcesDir = new File(resourcesUrl.getFile());
+      resourcesDir = new File(resourcesUrl.toURI().getPath());
       if (!resourcesDir.isDirectory()) {
-        Assert.fail("Resources file should be a directory");
+        Assert.fail("Resources file: " + resourcesDir.toString() +  " should be a directory");
       }
     } else {
       Assert.fail("Unable to find resources folder");


### PR DESCRIPTION
Fixes the problem where ResourcesFolderTest.java fails if there are spaces in the project directory name or in the parent directory name.
- - -
Also added `+ resourcesDir.toString() +` to failing test message to help future contributors debug
- - -
[URLDecoder ](https://docs.oracle.com/javase/7/docs/api/java/net/URLDecoder.html#decode(java.lang.String,%20java.lang.String))throws `UnsupportedEncodingException`. Looking at other tests, they throw `Exception` so I just followed suit.