### PR TITLE
Closes #122: Add partOfDay achievement functionality

### DIFF
--- a/src/main/java/org/mafagafogigante/dungeon/achievements/Achievement.java
+++ b/src/main/java/org/mafagafogigante/dungeon/achievements/Achievement.java
@@ -1,6 +1,7 @@
 package org.mafagafogigante.dungeon.achievements;
 
 import org.mafagafogigante.dungeon.game.Id;
+import org.mafagafogigante.dungeon.game.PartOfDay;
 import org.mafagafogigante.dungeon.stats.BattleStatistics;
 import org.mafagafogigante.dungeon.stats.ExplorationStatistics;
 import org.mafagafogigante.dungeon.stats.Statistics;
@@ -29,13 +30,13 @@ public class Achievement {
    */
   Achievement(String id, String name, String info, String text,
       Collection<BattleStatisticsRequirement> battleRequirements, CounterMap<Id> killsByLocationId,
-      CounterMap<Id> visitedLocations, CounterMap<Id> maximumNumberOfVisits) {
+      CounterMap<Id> visitedLocations, CounterMap<Id> maximumNumberOfVisits, CounterMap<PartOfDay> partOfDays) {
     this.id = new Id(id);
     this.name = name;
     this.info = info;
     this.text = text;
     battle = new BattleComponent(battleRequirements);
-    exploration = new ExplorationComponent(killsByLocationId, visitedLocations, maximumNumberOfVisits);
+    exploration = new ExplorationComponent(killsByLocationId, visitedLocations, maximumNumberOfVisits, partOfDays);
   }
 
   public Id getId() {

--- a/src/main/java/org/mafagafogigante/dungeon/achievements/AchievementBuilder.java
+++ b/src/main/java/org/mafagafogigante/dungeon/achievements/AchievementBuilder.java
@@ -1,6 +1,7 @@
 package org.mafagafogigante.dungeon.achievements;
 
 import org.mafagafogigante.dungeon.game.Id;
+import org.mafagafogigante.dungeon.game.PartOfDay;
 import org.mafagafogigante.dungeon.util.CounterMap;
 
 import java.util.ArrayList;
@@ -16,6 +17,7 @@ class AchievementBuilder {
   private CounterMap<Id> killsByLocationId;
   private CounterMap<Id> visitedLocations;
   private CounterMap<Id> maximumNumberOfVisits;
+  private CounterMap<PartOfDay> partOfDays;
 
   public void setId(String id) {
     this.id = id;
@@ -55,9 +57,15 @@ class AchievementBuilder {
     }
   }
 
+  public void setVisitedPartOfDay(CounterMap<PartOfDay> partOfDays) {
+    if (partOfDays.isNotEmpty()) {
+      this.partOfDays = partOfDays;
+    }
+  }
+
   public Achievement createAchievement() {
     return new Achievement(id, name, info, text, requirements, killsByLocationId, visitedLocations,
-        maximumNumberOfVisits);
+        maximumNumberOfVisits, partOfDays);
   }
 
 }

--- a/src/main/java/org/mafagafogigante/dungeon/achievements/AchievementStoreFactory.java
+++ b/src/main/java/org/mafagafogigante/dungeon/achievements/AchievementStoreFactory.java
@@ -69,6 +69,14 @@ public class AchievementStoreFactory {
     return counterMap;
   }
 
+  private static CounterMap<PartOfDay> partOfDayCounterMapFromJsonObject(JsonObject jsonObject) {
+    CounterMap<PartOfDay> counterMap = new CounterMap<>();
+    for (Member member : jsonObject) {
+      counterMap.incrementCounter(PartOfDay.getPartOfDayByName(member.getName()), member.getValue().asInt());
+    }
+    return counterMap;
+  }
+
   /**
    * Loads all provided achievements into the provided AchievementStore.
    *
@@ -130,6 +138,10 @@ public class AchievementStoreFactory {
         JsonValue visitedLocations = explorationRequirements.asObject().get("visitedLocations");
         if (visitedLocations != null) {
           builder.setVisitedLocations(idCounterMapFromJsonObject(visitedLocations.asObject()));
+        }
+        JsonValue partOfDays = explorationRequirements.asObject().get("partOfDay");
+        if (partOfDays != null) {
+          builder.setVisitedPartOfDay(partOfDayCounterMapFromJsonObject(partOfDays.asObject()));
         }
       }
       store.addAchievement(builder.createAchievement());

--- a/src/main/java/org/mafagafogigante/dungeon/achievements/ExplorationComponent.java
+++ b/src/main/java/org/mafagafogigante/dungeon/achievements/ExplorationComponent.java
@@ -1,6 +1,7 @@
 package org.mafagafogigante.dungeon.achievements;
 
 import org.mafagafogigante.dungeon.game.Id;
+import org.mafagafogigante.dungeon.game.PartOfDay;
 import org.mafagafogigante.dungeon.stats.ExplorationStatistics;
 import org.mafagafogigante.dungeon.util.CounterMap;
 
@@ -24,11 +25,14 @@ final class ExplorationComponent {
    */
   private final CounterMap<Id> maximumNumberOfVisits;
 
+  private final CounterMap<PartOfDay> partOfDays;
+
   ExplorationComponent(CounterMap<Id> killsByLocationId, CounterMap<Id> visitedLocations,
-      CounterMap<Id> maximumNumberOfVisits) {
+      CounterMap<Id> maximumNumberOfVisits, CounterMap<PartOfDay> partOfDays) {
     this.killsByLocationId = killsByLocationId;
     this.visitedLocations = visitedLocations;
     this.maximumNumberOfVisits = maximumNumberOfVisits;
+    this.partOfDays = partOfDays;
   }
 
   /**
@@ -52,6 +56,13 @@ final class ExplorationComponent {
     if (maximumNumberOfVisits != null) {
       for (Id locationId : maximumNumberOfVisits.keySet()) {
         if (explorationStatistics.getMaximumNumberOfVisits(locationId) < maximumNumberOfVisits.getCounter(locationId)) {
+          return false;
+        }
+      }
+    }
+    if (partOfDays != null) {
+      for (PartOfDay partOfDay : partOfDays.keySet()) {
+        if (explorationStatistics.getVisitsByPartOfDay(partOfDay) < partOfDays.getCounter(partOfDay)) {
           return false;
         }
       }

--- a/src/main/java/org/mafagafogigante/dungeon/entity/creatures/Observer.java
+++ b/src/main/java/org/mafagafogigante/dungeon/entity/creatures/Observer.java
@@ -182,7 +182,7 @@ public class Observer implements Serializable {
       if (world.hasLocationAt(adjacentPoint)) {
         Location adjacentLocation = world.getLocation(adjacentPoint);
         ExplorationStatistics explorationStatistics = Game.getGameState().getStatistics().getExplorationStatistics();
-        explorationStatistics.createEntryIfNotExists(adjacentPoint, adjacentLocation.getId());
+        explorationStatistics.createEntryIfNotExists(adjacentPoint, adjacentLocation.getId(), world.getWorldDate());
         String name = adjacentLocation.getName().getSingular();
         Color color = adjacentLocation.getDescription().getColor();
         ColoredString locationName = new ColoredString(name, color);

--- a/src/main/java/org/mafagafogigante/dungeon/entity/creatures/Walker.java
+++ b/src/main/java/org/mafagafogigante/dungeon/entity/creatures/Walker.java
@@ -70,7 +70,8 @@ class Walker implements Serializable {
 
   private void updateExplorationStatistics(Point destination) {
     ExplorationStatistics explorationStatistics = Game.getGameState().getStatistics().getExplorationStatistics();
-    explorationStatistics.addVisit(destination, Game.getGameState().getWorld().getLocation(destination).getId());
+    explorationStatistics.addVisit(destination, Game.getGameState().getWorld().getLocation(destination).getId(),
+        Game.getGameState().getWorld().getWorldDate());
   }
 
 }

--- a/src/main/java/org/mafagafogigante/dungeon/game/GameState.java
+++ b/src/main/java/org/mafagafogigante/dungeon/game/GameState.java
@@ -46,7 +46,8 @@ public class GameState implements Serializable {
     hero = world.getCreatureFactory().makeHero(world.getWorldDate(), world, statistics);
     heroPosition = new Point(0, 0, 0);
     world.getLocation(heroPosition).addCreature(hero);
-    getStatistics().getExplorationStatistics().addVisit(heroPosition, world.getLocation(heroPosition).getId());
+    getStatistics().getExplorationStatistics().addVisit(heroPosition, world.getLocation(heroPosition).getId(),
+        world.getWorldDate());
   }
 
   public CommandHistory getCommandHistory() {

--- a/src/main/java/org/mafagafogigante/dungeon/game/PartOfDay.java
+++ b/src/main/java/org/mafagafogigante/dungeon/game/PartOfDay.java
@@ -70,6 +70,23 @@ public enum PartOfDay implements Selectable {
   }
 
   /**
+   * Returns the PartOfDay constant corresponding to a given name.
+   *
+   * @param name a name corresponding to PartOfDay enum.
+   * @return a PartOfDay constant.
+   */
+  @NotNull
+  public static PartOfDay getPartOfDayByName(@NotNull String name) {
+    PartOfDay[] podArray = values();
+    for (int i = podArray.length - 1; i >= 0; i--) {
+      if (podArray[i].name().equalsIgnoreCase(name)) {
+        return podArray[i];
+      }
+    }
+    throw new AssertionError(); // Execution should never reach this line.
+  }
+
+  /**
    * @param cur the current time.
    * @param pod a part of the day.
    * @return the number of seconds between the current time and the start of the part of the day.
@@ -85,7 +102,7 @@ public enum PartOfDay implements Selectable {
     return luminosity;
   }
 
-  int getStartingHour() {
+  public int getStartingHour() {
     return startingHour;
   }
 

--- a/src/main/java/org/mafagafogigante/dungeon/stats/ExplorationStatisticsEntry.java
+++ b/src/main/java/org/mafagafogigante/dungeon/stats/ExplorationStatisticsEntry.java
@@ -1,6 +1,8 @@
 package org.mafagafogigante.dungeon.stats;
 
+import org.mafagafogigante.dungeon.date.Date;
 import org.mafagafogigante.dungeon.game.Id;
+import org.mafagafogigante.dungeon.game.PartOfDay;
 import org.mafagafogigante.dungeon.io.Version;
 
 import java.io.Serializable;
@@ -12,15 +14,21 @@ class ExplorationStatisticsEntry implements Serializable {
 
   private static final long serialVersionUID = Version.MAJOR;
   private final Id locationId;
+  private Date discoveredDate;
   private int visitCount;
   private int killCount;
 
-  public ExplorationStatisticsEntry(Id locationId) {
+  public ExplorationStatisticsEntry(Id locationId, Date discoveredDate) {
     this.locationId = locationId;
+    this.discoveredDate = discoveredDate;
   }
 
   public Id getLocationId() {
     return locationId;
+  }
+
+  public Date getDiscoveredDate() {
+    return discoveredDate;
   }
 
   /**
@@ -47,8 +55,8 @@ class ExplorationStatisticsEntry implements Serializable {
 
   @Override
   public String toString() {
-    String format = "ExplorationStatisticsEntry{locationId=%s, visitCount=%d, killCount=%d}";
-    return String.format(format, locationId, visitCount, killCount);
+    String format = "ExplorationStatisticsEntry{locationId=%s, visitCount=%d, killCount=%d, discoveredDate=%s}";
+    return String.format(format, locationId, visitCount, killCount, discoveredDate);
   }
 
 }

--- a/src/main/resources/achievements.json
+++ b/src/main/resources/achievements.json
@@ -666,6 +666,28 @@
           "GRAVEYARD": 10
         }
       }
+    },
+    {
+      "id": "I_DONT_NEED_NO_SUNLIGHT",
+      "name": "I don't need no sunlight",
+      "info": "Discover 10 new locations at midnight.",
+      "text": "discovered 10 new locations at midnight",
+      "explorationRequirements": {
+        "partOfDay": {
+          "MIDNIGHT": 10
+        }
+      }
+    },
+    {
+      "id": "MORNING_WALK",
+      "name": "Morning Walk",
+      "info": "Discover 10 new locations at morning.",
+      "text": "discovered 10 new locations at morning",
+      "explorationRequirements": {
+        "partOfDay": {
+          "MORNING": 10
+        }
+      }
     }
   ]
 }

--- a/src/test/java/org/mafagafogigante/dungeon/achievements/AchievementTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/achievements/AchievementTest.java
@@ -1,5 +1,6 @@
 package org.mafagafogigante.dungeon.achievements;
 
+import org.mafagafogigante.dungeon.date.Date;
 import org.mafagafogigante.dungeon.entity.creatures.Creature;
 import org.mafagafogigante.dungeon.entity.creatures.CreaturePreset;
 import org.mafagafogigante.dungeon.game.Id;
@@ -55,11 +56,14 @@ public class AchievementTest {
 
     Statistics statistics = new Statistics();
     Assert.assertFalse(achievement.isFulfilled(statistics));
-    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("DESERT"));
+    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("DESERT"),
+        new Date(PartOfDay.DAWN.getStartingHour()));
     Assert.assertFalse(achievement.isFulfilled(statistics));
-    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("DESERT"));
+    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("DESERT"),
+        new Date(PartOfDay.DAWN.getStartingHour()));
     Assert.assertFalse(achievement.isFulfilled(statistics));
-    statistics.getExplorationStatistics().addVisit(new Point(1, 1, 1), new Id("DESERT"));
+    statistics.getExplorationStatistics().addVisit(new Point(1, 1, 1), new Id("DESERT"),
+        new Date(PartOfDay.DAWN.getStartingHour()));
     Assert.assertTrue(achievement.isFulfilled(statistics));
   }
 
@@ -75,11 +79,14 @@ public class AchievementTest {
 
     Statistics statistics = new Statistics();
     Assert.assertFalse(achievement.isFulfilled(statistics));
-    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("DESERT"));
+    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("DESERT"),
+        new Date(PartOfDay.DAWN.getStartingHour()));
     Assert.assertFalse(achievement.isFulfilled(statistics));
-    statistics.getExplorationStatistics().addVisit(new Point(1, 1, 1), new Id("DESERT"));
+    statistics.getExplorationStatistics().addVisit(new Point(1, 1, 1), new Id("DESERT"),
+        new Date(PartOfDay.DAWN.getStartingHour()));
     Assert.assertFalse(achievement.isFulfilled(statistics));
-    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("DESERT"));
+    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("DESERT"),
+        new Date(PartOfDay.DAWN.getStartingHour()));
     Assert.assertTrue(achievement.isFulfilled(statistics));
   }
 

--- a/src/test/java/org/mafagafogigante/dungeon/achievements/AchievementTrackerTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/achievements/AchievementTrackerTest.java
@@ -4,6 +4,7 @@ import org.mafagafogigante.dungeon.achievements.comparators.UnlockedAchievementC
 import org.mafagafogigante.dungeon.date.Date;
 import org.mafagafogigante.dungeon.date.DungeonTimeUnit;
 import org.mafagafogigante.dungeon.game.Id;
+import org.mafagafogigante.dungeon.game.PartOfDay;
 import org.mafagafogigante.dungeon.game.Point;
 import org.mafagafogigante.dungeon.stats.Statistics;
 import org.mafagafogigante.dungeon.util.CounterMap;
@@ -82,7 +83,8 @@ public class AchievementTrackerTest {
 
     Assert.assertTrue(tracker.hasNotBeenUnlocked(achievement));
 
-    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("PLACE"));
+    statistics.getExplorationStatistics().addVisit(new Point(0, 0, 0), new Id("PLACE"),
+        new Date(PartOfDay.DAWN.getStartingHour()));
 
     Assert.assertTrue(tracker.hasNotBeenUnlocked(achievement));
 

--- a/src/test/java/org/mafagafogigante/dungeon/io/AchievementsJsonFileTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/io/AchievementsJsonFileTest.java
@@ -23,6 +23,8 @@ public class AchievementsJsonFileTest extends ResourcesTypeTest {
   private static final String RIVERSIDE_FIELD = "RIVERSIDE";
   private static final String GRAVEYARD_FIELD = "GRAVEYARD";
   private static final String PART_OF_DAY_FIELD = "partOfDay";
+  private static final String MIDNIGHT_FIELD = "MIDNIGHT";
+  private static final String MORNING_FIELD = "MORNING";
   private static final String ACHIEVEMENTS_FIELD = "achievements";
   private static final String STONE_BRIDGE_FIELD = "STONE_BRIDGE";
   private static final String CAUSE_OF_DEATH_FIELD = "causeOfDeath";
@@ -31,6 +33,7 @@ public class AchievementsJsonFileTest extends ResourcesTypeTest {
   private static final String BATTLE_REQUIREMENTS_FIELD = "battleRequirements";
   private static final String KILLS_BY_LOCATION_ID_FIELD = "killsByLocationID";
   private static final String MAXIMUM_NUMBER_OF_VISITS_FIELD = "maximumNumberOfVisits";
+  private static final String VISITS_BY_PART_OF_DAY = "partOfDay";
   private static final String EXPLORATION_REQUIREMENTS_FIELD = "explorationRequirements";
 
   @Test
@@ -41,6 +44,7 @@ public class AchievementsJsonFileTest extends ResourcesTypeTest {
     JsonRule visitedLocationsRule = getVisitedLocationsRule();
     JsonRule maximumNumberOfVisitsRule = getMaximumNumberOfVisitsRule();
     JsonRule killsByLocationIdRule = getKillsByLocationIdRule();
+    JsonRule visitedByPartOfDayRule = getVisitedByPartOfDayRule();
     Map<String, JsonRule> explorationRequirementsRules = new HashMap<>();
     JsonRule optionalKillsByLocationRule = JsonRuleFactory.makeOptionalRule(killsByLocationIdRule);
     explorationRequirementsRules.put(KILLS_BY_LOCATION_ID_FIELD, optionalKillsByLocationRule);
@@ -48,6 +52,8 @@ public class AchievementsJsonFileTest extends ResourcesTypeTest {
     explorationRequirementsRules.put(MAXIMUM_NUMBER_OF_VISITS_FIELD, optionalMaximumNumberRule);
     JsonRule optionalVisitedLocationsRule = JsonRuleFactory.makeOptionalRule(visitedLocationsRule);
     explorationRequirementsRules.put(VISITED_LOCATIONS_FIELD, optionalVisitedLocationsRule);
+    JsonRule optionalVisitedByPartOfDayRule = JsonRuleFactory.makeOptionalRule(visitedByPartOfDayRule);
+    explorationRequirementsRules.put(VISITS_BY_PART_OF_DAY, optionalVisitedByPartOfDayRule);
     JsonRule explorationRequirementsRule = JsonRuleFactory.makeObjectRule(explorationRequirementsRules);
     JsonRule achievementRule = makeAchievementsRule(explorationRequirementsRule, battleRequirementsRule);
     JsonRule achievementsFileRule = getAchievementsFileRule(achievementRule);
@@ -125,6 +131,14 @@ public class AchievementsJsonFileTest extends ResourcesTypeTest {
     visitedLocationsRules.put(RIVERSIDE_FIELD, optionalIntegerRule);
     visitedLocationsRules.put(GRAVEYARD_FIELD, optionalIntegerRule);
     return JsonRuleFactory.makeObjectRule(visitedLocationsRules);
+  }
+
+  private JsonRule getVisitedByPartOfDayRule() {
+    Map<String, JsonRule> visitedByPartOfDayRules = new HashMap<>();
+    JsonRule optionalIntegerRule = JsonRuleFactory.makeOptionalRule(JsonRuleFactory.makeIntegerRule());
+    visitedByPartOfDayRules.put(MIDNIGHT_FIELD, optionalIntegerRule);
+    visitedByPartOfDayRules.put(MORNING_FIELD, optionalIntegerRule);
+    return JsonRuleFactory.makeObjectRule(visitedByPartOfDayRules);
   }
 
 }


### PR DESCRIPTION
### ExplorationStatisticsEntry now keeps track of when the location was discovered
ExplorationStatisticsEntry has a new field that stores the date of when a location was discovered, which is used for the achievements.
- - -
### Added functionality to read a new achievement corresponding to partOfDay for exploration statistics
I was only able to add the first 2 achievements (Morning, and Midnight). I was unsure how to implement the other ones. For the most part I just followed `visitedLocations` and `maximumNumberOfVisits` to read the JSON object.
- - -
### ExplorationStatistics keeps track of distinct locations via partOfDay and can return the amount of distinct locations via partOfDay
Created functions for the above functionality. Also created a function in `PartOfDay` class to return a `PartOfDay` object corresponding to `PartOfDay` name given (Used for the process of reading achievement JSON file).
- - -
### Not done
May need extra tests for this new functionality.

May need statistics about this in the debug command "exploration" in the `CommandSet` class.